### PR TITLE
nf-core style implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,14 +16,12 @@ concurrency:
 
 jobs:
   test:
-    name: Run pipeline with test data
+    name: Stub test pipeline
     runs-on: ubuntu-latest
     strategy:
       matrix:
         NXF_VER:
           - "23.04.0"
-        RUN_CONFIG:
-          - "-profile local,docker -stub -c ./tests/stub/stub.config --max_cpus 2 --max_memory '6.GB' --max_time '1.h'"
     steps:
       - name: Check out pipeline code
         uses: actions/checkout@v4
@@ -33,6 +31,10 @@ jobs:
         with:
           version: ${{ matrix.NXF_VER }}
 
-      - name: Run pipeline with test data
+      - name: Stub test pipeline
         run: |
-          nextflow run ${GITHUB_WORKSPACE} --outdir ./results ${{ matrix.RUN_CONFIG }}
+          nextflow run ${GITHUB_WORKSPACE} \
+          -profile local,docker \
+          -stub \
+          -c conf/test.config \
+          --max_cpus 2 --max_memory '6.GB' --max_time '1.h'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: Linux/Docker -stub test
+on:
+  push:
+    branches:
+      - nextflow
+  pull_request:
+    branches:
+      - nextflow
+
+env:
+  NXF_ANSI_LOG: false
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Run pipeline with test data
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        NXF_VER:
+          - "23.04.0"
+        RUN_CONFIG:
+          - "-profile local,docker -stub -c ./tests/stub/stub.config --max_cpus 2 --max_memory '6.GB' --max_time '1.h'"
+    steps:
+      - name: Check out pipeline code
+        uses: actions/checkout@v4
+
+      - name: Install Nextflow
+        uses: nf-core/setup-nextflow@v1
+        with:
+          version: ${{ matrix.NXF_VER }}
+
+      - name: Run pipeline with test data
+        run: |
+          nextflow run ${GITHUB_WORKSPACE} --outdir ./results ${{ matrix.RUN_CONFIG }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,17 @@
 bin/TIR-Learner*/Module3/Maize_model.sav
 *.pyc
+
+// NextFlow
+.nextflow*
+work/
+results/
+.DS_Store
+*.code-workspace
+.screenrc
+.*.sw?
+__pycache__
+*.pyo
+*.pyc
+
+*.stdout
+*.stderr

--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -1,0 +1,1 @@
+repository_type: pipeline

--- a/cleanNXF.sh
+++ b/cleanNXF.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+rm -rf .nextflow*
+echo "Cleaned .nextflow..."
+rm -rf .nextflow.pid
+echo "Cleaned .nextflow.pid..."
+for i in $(ls work | grep -v "conda");
+do
+    rm -rf "work/$i"
+done
+echo "Cleaned work..."

--- a/conf/base.config
+++ b/conf/base.config
@@ -1,0 +1,156 @@
+profiles {
+    pfr {
+        process {
+            executor            = 'slurm'
+        }
+
+        apptainer {
+            envWhitelist        = 'APPTAINER_BINDPATH,APPTAINER_BIND'
+            cacheDir            = "/workspace/pangene/singularity"
+        }
+    }
+
+    local {
+        process {
+            executor            = 'local'
+        }
+    }
+
+    conda {
+        conda.enabled          = true
+        docker.enabled         = false
+        singularity.enabled    = false
+        podman.enabled         = false
+        shifter.enabled        = false
+        charliecloud.enabled   = false
+        channels               = ['conda-forge', 'bioconda', 'defaults']
+        apptainer.enabled      = false
+    }
+    mamba {
+        conda.enabled          = true
+        conda.useMamba         = true
+        docker.enabled         = false
+        singularity.enabled    = false
+        podman.enabled         = false
+        shifter.enabled        = false
+        charliecloud.enabled   = false
+        apptainer.enabled      = false
+    }
+    docker {
+        docker.enabled         = true
+        conda.enabled          = false
+        singularity.enabled    = false
+        podman.enabled         = false
+        shifter.enabled        = false
+        charliecloud.enabled   = false
+        apptainer.enabled      = false
+        docker.runOptions      = '-u $(id -u):$(id -g)'
+    }
+    arm {
+        docker.runOptions      = '-u $(id -u):$(id -g) --platform=linux/amd64'
+    }
+    singularity {
+        singularity.enabled    = true
+        singularity.autoMounts = true
+        conda.enabled          = false
+        docker.enabled         = false
+        podman.enabled         = false
+        shifter.enabled        = false
+        charliecloud.enabled   = false
+        apptainer.enabled      = false
+    }
+    apptainer {
+        apptainer.enabled      = true
+        apptainer.autoMounts   = true
+        conda.enabled          = false
+        docker.enabled         = false
+        singularity.enabled    = false
+        podman.enabled         = false
+        shifter.enabled        = false
+        charliecloud.enabled   = false
+    }
+}
+
+apptainer.registry              = 'quay.io'
+docker.registry                 = 'quay.io'
+podman.registry                 = 'quay.io'
+singularity.registry            = 'quay.io'
+
+process {
+
+    cpus                        = { check_max( 1    * task.attempt, 'cpus'   ) }
+    memory                      = { check_max( 6.GB * task.attempt, 'memory' ) }
+    time                        = { check_max( 4.h  * task.attempt, 'time'   ) }
+
+    errorStrategy               = { task.exitStatus in [140,143,137,104,134,139] ? 'retry' : 'finish' }
+    maxRetries                  = 1
+    maxErrors                   = '-1'
+
+    withLabel:process_single {
+        cpus                    = { check_max( 1                  , 'cpus'     ) }
+        memory                  = { check_max( 6.GB * task.attempt, 'memory'   ) }
+        time                    = { check_max( 4.h  * task.attempt, 'time'     ) }
+    }
+    withLabel:process_low {
+        cpus                    = { check_max( 2     * task.attempt, 'cpus'    ) }
+        memory                  = { check_max( 12.GB * task.attempt, 'memory'  ) }
+        time                    = { check_max( 4.h   * task.attempt, 'time'    ) }
+    }
+    withLabel:process_medium {
+        cpus                    = { check_max( 6     * task.attempt, 'cpus'    ) }
+        memory                  = { check_max( 36.GB * task.attempt, 'memory'  ) }
+        time                    = { check_max( 8.h   * task.attempt, 'time'    ) }
+    }
+    withLabel:process_high {
+        cpus                    = { check_max( 12    * task.attempt, 'cpus'    ) }
+        memory                  = { check_max( 72.GB * task.attempt, 'memory'  ) }
+        time                    = { check_max( 16.h  * task.attempt, 'time'    ) }
+    }
+    withLabel:process_long {
+        time                    = { check_max( 20.h  * task.attempt, 'time'    ) }
+    }
+    withLabel:process_high_memory {
+        memory                  = { check_max( 200.GB * task.attempt, 'memory' ) }
+    }
+
+    withName:CUSTOM_DUMPSOFTWAREVERSIONS {
+        cache = false
+    }
+}
+
+nextflow {
+    enable {
+        moduleBinaries          = true
+    }
+}
+
+def check_max(obj, type) {
+    if (type == 'memory') {
+        try {
+            if (obj.compareTo(params.max_memory as nextflow.util.MemoryUnit) == 1)
+                return params.max_memory as nextflow.util.MemoryUnit
+            else
+                return obj
+        } catch (all) {
+            println "   ### ERROR ###   Max memory '${params.max_memory}' is not valid! Using default value: $obj"
+            return obj
+        }
+    } else if (type == 'time') {
+        try {
+            if (obj.compareTo(params.max_time as nextflow.util.Duration) == 1)
+                return params.max_time as nextflow.util.Duration
+            else
+                return obj
+        } catch (all) {
+            println "   ### ERROR ###   Max time '${params.max_time}' is not valid! Using default value: $obj"
+            return obj
+        }
+    } else if (type == 'cpus') {
+        try {
+            return Math.min( obj, params.max_cpus as int )
+        } catch (all) {
+            println "   ### ERROR ###   Max cpus '${params.max_cpus}' is not valid! Using default value: $obj"
+            return obj
+        }
+    }
+}

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -1,0 +1,29 @@
+process {
+    withName: CUSTOM_DUMPSOFTWAREVERSIONS {
+        publishDir = [
+            path: { "${params.outdir}/pipeline_info" },
+            mode: params.publish_dir_mode,
+            pattern: '*_versions.yml'
+        ]
+    }
+
+    withName: CUSTOM_SHORTENFASTAIDS {
+        publishDir = [
+            path: { "${params.outdir}" },
+            mode: params.publish_dir_mode,
+            pattern: '*.short.ids.tsv'
+        ]
+    }
+
+    withName: LTRHARVEST {
+        ext.prefix = { "${meta.id}_ltrharvest" }
+    }
+
+    withName: LTRFINDER {
+        ext.args = '-harvest_out -size 1000000 -time 300'
+    }
+
+    withName: CAT_CAT {
+        ext.prefix = { "${meta.id}_ltrharvest_ltrfinder.tabout" }
+    }
+}

--- a/conf/reporting_defaults.config
+++ b/conf/reporting_defaults.config
@@ -1,0 +1,13 @@
+def trace_timestamp         = new java.util.Date().format( 'yyyy-MM-dd_HH-mm-ss')
+timeline {
+    enabled                 = true
+    file                    = "${params.outdir}/pipeline_info/execution_timeline_${trace_timestamp}.html"
+}
+report {
+    enabled                 = true
+    file                    = "${params.outdir}/pipeline_info/execution_report_${trace_timestamp}.html"
+}
+trace {
+    enabled                 = true
+    file                    = "${params.outdir}/pipeline_info/execution_trace_${trace_timestamp}.txt"
+}

--- a/conf/test.config
+++ b/conf/test.config
@@ -1,0 +1,3 @@
+params {
+    genomes     = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/eukaryotes/actinidia_chinensis/genome/chr1/genome.fasta.gz'
+}

--- a/modules.json
+++ b/modules.json
@@ -1,0 +1,58 @@
+{
+  "name": "",
+  "homePage": "",
+  "repos": {
+    "git@github.com:PlantandFoodResearch/nxf-modules.git": {
+      "modules": {
+        "pfr": {
+          "custom/restoregffids": {
+            "branch": "main",
+            "git_sha": "e9f6bdd634bdbcd52c5568ba82f16176ec06631f",
+            "installed_by": ["modules"]
+          },
+          "custom/shortenfastaids": {
+            "branch": "main",
+            "git_sha": "5e0e41b51d7fc7f68ae43692b6fe19b95d7f3a8c",
+            "installed_by": ["modules"]
+          }
+        }
+      }
+    },
+    "https://github.com/nf-core/modules.git": {
+      "modules": {
+        "nf-core": {
+          "cat/cat": {
+            "branch": "master",
+            "git_sha": "9437e6053dccf4aafa022bfd6e7e9de67e625af8",
+            "installed_by": ["modules"]
+          },
+          "custom/dumpsoftwareversions": {
+            "branch": "master",
+            "git_sha": "de45447d060b8c8b98575bc637a4a575fd0638e1",
+            "installed_by": ["modules"]
+          },
+          "gunzip": {
+            "branch": "master",
+            "git_sha": "3a5fef109d113b4997c9822198664ca5f2716208",
+            "installed_by": ["modules"]
+          },
+          "ltrfinder": {
+            "branch": "master",
+            "git_sha": "85b12bcdd6a5fee149fe3d5e8262c05123e8eab7",
+            "installed_by": ["modules"]
+          },
+          "ltrharvest": {
+            "branch": "master",
+            "git_sha": "e12e44e962ebbf20b49de0c71f21111ad2e64da3",
+            "installed_by": ["modules"]
+          },
+          "ltrretriever/ltrretriever": {
+            "branch": "master",
+            "git_sha": "0aef23e5aa5141aafea3b1e47c57ef7594644787",
+            "installed_by": ["modules"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/modules/nf-core/cat/cat/environment.yml
+++ b/modules/nf-core/cat/cat/environment.yml
@@ -1,0 +1,7 @@
+name: cat_cat
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - conda-forge::pigz=2.3.4

--- a/modules/nf-core/cat/cat/main.nf
+++ b/modules/nf-core/cat/cat/main.nf
@@ -1,0 +1,79 @@
+process CAT_CAT {
+    tag "$meta.id"
+    label 'process_low'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/pigz:2.3.4' :
+        'biocontainers/pigz:2.3.4' }"
+
+    input:
+    tuple val(meta), path(files_in)
+
+    output:
+    tuple val(meta), path("${prefix}"), emit: file_out
+    path "versions.yml"               , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def args2 = task.ext.args2 ?: ''
+    def file_list = files_in.collect { it.toString() }
+
+    // choose appropriate concatenation tool depending on input and output format
+
+    // | input     | output     | command1 | command2 |
+    // |-----------|------------|----------|----------|
+    // | gzipped   | gzipped    | cat      |          |
+    // | ungzipped | ungzipped  | cat      |          |
+    // | gzipped   | ungzipped  | zcat     |          |
+    // | ungzipped | gzipped    | cat      | pigz     |
+
+    // Use input file ending as default
+    prefix   = task.ext.prefix ?: "${meta.id}${getFileSuffix(file_list[0])}"
+    out_zip  = prefix.endsWith('.gz')
+    in_zip   = file_list[0].endsWith('.gz')
+    command1 = (in_zip && !out_zip) ? 'zcat' : 'cat'
+    command2 = (!in_zip && out_zip) ? "| pigz -c -p $task.cpus $args2" : ''
+    if(file_list.contains(prefix.trim())) {
+        error "The name of the input file can't be the same as for the output prefix in the " +
+        "module CAT_CAT (currently `$prefix`). Please choose a different one."
+    }
+    """
+    $command1 \\
+        $args \\
+        ${file_list.join(' ')} \\
+        $command2 \\
+        > ${prefix}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        pigz: \$( pigz --version 2>&1 | sed 's/pigz //g' )
+    END_VERSIONS
+    """
+
+    stub:
+    def file_list   = files_in.collect { it.toString() }
+    prefix          = task.ext.prefix ?: "${meta.id}${file_list[0].substring(file_list[0].lastIndexOf('.'))}"
+    if(file_list.contains(prefix.trim())) {
+        error "The name of the input file can't be the same as for the output prefix in the " +
+        "module CAT_CAT (currently `$prefix`). Please choose a different one."
+    }
+    """
+    touch $prefix
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        pigz: \$( pigz --version 2>&1 | sed 's/pigz //g' )
+    END_VERSIONS
+    """
+}
+
+// for .gz files also include the second to last extension if it is present. E.g., .fasta.gz
+def getFileSuffix(filename) {
+    def match = filename =~ /^.*?((\.\w{1,5})?(\.\w{1,5}\.gz$))/
+    return match ? match[0][1] : filename.substring(filename.lastIndexOf('.'))
+}
+

--- a/modules/nf-core/cat/cat/meta.yml
+++ b/modules/nf-core/cat/cat/meta.yml
@@ -1,0 +1,36 @@
+name: cat_cat
+description: A module for concatenation of gzipped or uncompressed files
+keywords:
+  - concatenate
+  - gzip
+  - cat
+tools:
+  - cat:
+      description: Just concatenation
+      documentation: https://man7.org/linux/man-pages/man1/cat.1.html
+      licence: ["GPL-3.0-or-later"]
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - files_in:
+      type: file
+      description: List of compressed / uncompressed files
+      pattern: "*"
+output:
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - file_out:
+      type: file
+      description: Concatenated file. Will be gzipped if file_out ends with ".gz"
+      pattern: "${file_out}"
+authors:
+  - "@erikrikarddaniel"
+  - "@FriederikeHanssen"
+maintainers:
+  - "@erikrikarddaniel"
+  - "@FriederikeHanssen"

--- a/modules/nf-core/cat/cat/tests/main.nf.test
+++ b/modules/nf-core/cat/cat/tests/main.nf.test
@@ -1,0 +1,178 @@
+nextflow_process {
+
+    name "Test Process CAT_CAT"
+    script "../main.nf"
+    process "CAT_CAT"
+    tag "modules"
+    tag "modules_nfcore"
+    tag "cat"
+    tag "cat/cat"
+
+    test("test_cat_name_conflict") {
+        when {
+            params {
+                outdir   = "${outputDir}"
+            }
+            process {
+                """
+                input[0] =
+                    [
+                        [ id:'genome', single_end:true ],
+                        [
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true),
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.sizes', checkIfExists: true)
+                        ]
+                    ]
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert !process.success },
+                { assert process.stdout.toString().contains("The name of the input file can't be the same as for the output prefix") }
+            )
+        }
+    }
+
+    test("test_cat_unzipped_unzipped") {
+        when {
+            params {
+                outdir   = "${outputDir}"
+            }
+            process {
+                """
+                input[0] =
+                    [
+                        [ id:'test', single_end:true ],
+                        [
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true),
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.sizes', checkIfExists: true)
+                        ]
+                    ]
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+
+    test("test_cat_zipped_zipped") {
+        when {
+            params {
+                outdir   = "${outputDir}"
+            }
+            process {
+                """
+                input[0] =
+                    [
+                        [ id:'test', single_end:true ],
+                        [
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.gff3.gz', checkIfExists: true),
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/alignment/last/contigs.genome.maf.gz', checkIfExists: true)
+                        ]
+                    ]
+                """
+            }
+        }
+        then {
+            def lines = path(process.out.file_out.get(0).get(1)).linesGzip
+            assertAll(
+                { assert process.success },
+                { assert snapshot(lines[0..5]).match("test_cat_zipped_zipped_lines") },
+                { assert snapshot(lines.size()).match("test_cat_zipped_zipped_size")}
+            )
+        }
+    }
+
+    test("test_cat_zipped_unzipped") {
+        config './nextflow_zipped_unzipped.config'
+
+        when {
+            params {
+                outdir   = "${outputDir}"
+            }
+            process {
+                """
+                input[0] =
+                    [
+                        [ id:'test', single_end:true ],
+                        [
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.gff3.gz', checkIfExists: true),
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/alignment/last/contigs.genome.maf.gz', checkIfExists: true)
+                        ]
+                    ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+    test("test_cat_unzipped_zipped") {
+        config './nextflow_unzipped_zipped.config'
+        when {
+            params {
+                outdir   = "${outputDir}"
+            }
+            process {
+                """
+                input[0] =
+                    [
+                        [ id:'test', single_end:true ],
+                        [
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true),
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.sizes', checkIfExists: true)
+                        ]
+                    ]
+                """
+            }
+        }
+        then {
+            def lines = path(process.out.file_out.get(0).get(1)).linesGzip
+            assertAll(
+                { assert process.success },
+                { assert snapshot(lines[0..5]).match("test_cat_unzipped_zipped_lines") },
+                { assert snapshot(lines.size()).match("test_cat_unzipped_zipped_size")}
+            )
+        }
+    }
+
+    test("test_cat_one_file_unzipped_zipped") {
+        config './nextflow_unzipped_zipped.config'
+        when {
+            params {
+                outdir   = "${outputDir}"
+            }
+            process {
+                """
+                input[0] =
+                    [
+                        [ id:'test', single_end:true ],
+                        [
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                        ]
+                    ]
+                """
+            }
+        }
+        then {
+            def lines = path(process.out.file_out.get(0).get(1)).linesGzip
+            assertAll(
+                { assert process.success },
+                { assert snapshot(lines[0..5]).match("test_cat_one_file_unzipped_zipped_lines") },
+                { assert snapshot(lines.size()).match("test_cat_one_file_unzipped_zipped_size")}
+            )
+        }
+    }
+}

--- a/modules/nf-core/cat/cat/tests/main.nf.test.snap
+++ b/modules/nf-core/cat/cat/tests/main.nf.test.snap
@@ -1,0 +1,121 @@
+{
+    "test_cat_unzipped_zipped_size": {
+        "content": [
+            375
+        ],
+        "timestamp": "2023-10-16T14:33:08.049445686"
+    },
+    "test_cat_unzipped_unzipped": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fasta:md5,f44b33a0e441ad58b2d3700270e2dbe2"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,115ed6177ebcff24eb99d503fa5ef894"
+                ],
+                "file_out": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fasta:md5,f44b33a0e441ad58b2d3700270e2dbe2"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,115ed6177ebcff24eb99d503fa5ef894"
+                ]
+            }
+        ],
+        "timestamp": "2023-10-16T14:32:18.500464399"
+    },
+    "test_cat_zipped_unzipped": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "cat.txt:md5,c439d3b60e7bc03e8802a451a0d9a5d9"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,115ed6177ebcff24eb99d503fa5ef894"
+                ],
+                "file_out": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "cat.txt:md5,c439d3b60e7bc03e8802a451a0d9a5d9"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,115ed6177ebcff24eb99d503fa5ef894"
+                ]
+            }
+        ],
+        "timestamp": "2023-10-16T14:32:49.642741302"
+    },
+    "test_cat_zipped_zipped_lines": {
+        "content": [
+            [
+                "MT192765.1\tGenbank\ttranscript\t259\t29667\t.\t+\t.\tID=unknown_transcript_1;geneID=orf1ab;gene_name=orf1ab",
+                "MT192765.1\tGenbank\tgene\t259\t21548\t.\t+\t.\tParent=unknown_transcript_1",
+                "MT192765.1\tGenbank\tCDS\t259\t13461\t.\t+\t0\tParent=unknown_transcript_1;exception=\"ribosomal slippage\";gbkey=CDS;gene=orf1ab;note=\"pp1ab;translated=by -1 ribosomal frameshift\";product=\"orf1ab polyprotein\";protein_id=QIK50426.1",
+                "MT192765.1\tGenbank\tCDS\t13461\t21548\t.\t+\t0\tParent=unknown_transcript_1;exception=\"ribosomal slippage\";gbkey=CDS;gene=orf1ab;note=\"pp1ab;translated=by -1 ribosomal frameshift\";product=\"orf1ab polyprotein\";protein_id=QIK50426.1",
+                "MT192765.1\tGenbank\tCDS\t21556\t25377\t.\t+\t0\tParent=unknown_transcript_1;gbkey=CDS;gene=S;note=\"structural protein\";product=\"surface glycoprotein\";protein_id=QIK50427.1",
+                "MT192765.1\tGenbank\tgene\t21556\t25377\t.\t+\t.\tParent=unknown_transcript_1"
+            ]
+        ],
+        "timestamp": "2023-10-16T14:32:33.629048645"
+    },
+    "test_cat_unzipped_zipped_lines": {
+        "content": [
+            [
+                ">MT192765.1 Severe acute respiratory syndrome coronavirus 2 isolate SARS-CoV-2/human/USA/PC00101P/2020, complete genome",
+                "GTTTATACCTTCCCAGGTAACAAACCAACCAACTTTCGATCTCTTGTAGATCTGTTCTCTAAACGAACTTTAAAATCTGT",
+                "GTGGCTGTCACTCGGCTGCATGCTTAGTGCACTCACGCAGTATAATTAATAACTAATTACTGTCGTTGACAGGACACGAG",
+                "TAACTCGTCTATCTTCTGCAGGCTGCTTACGGTTTCGTCCGTGTTGCAGCCGATCATCAGCACATCTAGGTTTTGTCCGG",
+                "GTGTGACCGAAAGGTAAGATGGAGAGCCTTGTCCCTGGTTTCAACGAGAAAACACACGTCCAACTCAGTTTGCCTGTTTT",
+                "ACAGGTTCGCGACGTGCTCGTACGTGGCTTTGGAGACTCCGTGGAGGAGGTCTTATCAGAGGCACGTCAACATCTTAAAG"
+            ]
+        ],
+        "timestamp": "2023-10-16T14:33:08.038830506"
+    },
+    "test_cat_one_file_unzipped_zipped_lines": {
+        "content": [
+            [
+                ">MT192765.1 Severe acute respiratory syndrome coronavirus 2 isolate SARS-CoV-2/human/USA/PC00101P/2020, complete genome",
+                "GTTTATACCTTCCCAGGTAACAAACCAACCAACTTTCGATCTCTTGTAGATCTGTTCTCTAAACGAACTTTAAAATCTGT",
+                "GTGGCTGTCACTCGGCTGCATGCTTAGTGCACTCACGCAGTATAATTAATAACTAATTACTGTCGTTGACAGGACACGAG",
+                "TAACTCGTCTATCTTCTGCAGGCTGCTTACGGTTTCGTCCGTGTTGCAGCCGATCATCAGCACATCTAGGTTTTGTCCGG",
+                "GTGTGACCGAAAGGTAAGATGGAGAGCCTTGTCCCTGGTTTCAACGAGAAAACACACGTCCAACTCAGTTTGCCTGTTTT",
+                "ACAGGTTCGCGACGTGCTCGTACGTGGCTTTGGAGACTCCGTGGAGGAGGTCTTATCAGAGGCACGTCAACATCTTAAAG"
+            ]
+        ],
+        "timestamp": "2023-10-16T14:33:21.39642399"
+    },
+    "test_cat_zipped_zipped_size": {
+        "content": [
+            78
+        ],
+        "timestamp": "2023-10-16T14:32:33.641869244"
+    },
+    "test_cat_one_file_unzipped_zipped_size": {
+        "content": [
+            374
+        ],
+        "timestamp": "2023-10-16T14:33:21.4094373"
+    }
+}

--- a/modules/nf-core/cat/cat/tests/nextflow_unzipped_zipped.config
+++ b/modules/nf-core/cat/cat/tests/nextflow_unzipped_zipped.config
@@ -1,0 +1,6 @@
+
+process {
+    withName: CAT_CAT {
+        ext.prefix = 'cat.txt.gz'
+    }
+}

--- a/modules/nf-core/cat/cat/tests/nextflow_zipped_unzipped.config
+++ b/modules/nf-core/cat/cat/tests/nextflow_zipped_unzipped.config
@@ -1,0 +1,8 @@
+
+process {
+
+    withName: CAT_CAT {
+        ext.prefix = 'cat.txt'
+    }
+
+}

--- a/modules/nf-core/cat/cat/tests/tags.yml
+++ b/modules/nf-core/cat/cat/tests/tags.yml
@@ -1,0 +1,2 @@
+cat/cat:
+  - modules/nf-core/cat/cat/**

--- a/modules/nf-core/custom/dumpsoftwareversions/environment.yml
+++ b/modules/nf-core/custom/dumpsoftwareversions/environment.yml
@@ -1,0 +1,7 @@
+name: custom_dumpsoftwareversions
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::multiqc=1.20

--- a/modules/nf-core/custom/dumpsoftwareversions/main.nf
+++ b/modules/nf-core/custom/dumpsoftwareversions/main.nf
@@ -1,0 +1,24 @@
+process CUSTOM_DUMPSOFTWAREVERSIONS {
+    label 'process_single'
+
+    // Requires `pyyaml` which does not have a dedicated container but is in the MultiQC container
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/multiqc:1.20--pyhdfd78af_0' :
+        'biocontainers/multiqc:1.20--pyhdfd78af_0' }"
+
+    input:
+    path versions
+
+    output:
+    path "software_versions.yml"    , emit: yml
+    path "software_versions_mqc.yml", emit: mqc_yml
+    path "versions.yml"             , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    template 'dumpsoftwareversions.py'
+}

--- a/modules/nf-core/custom/dumpsoftwareversions/meta.yml
+++ b/modules/nf-core/custom/dumpsoftwareversions/meta.yml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: custom_dumpsoftwareversions
+description: Custom module used to dump software versions within the nf-core pipeline template
+keywords:
+  - custom
+  - dump
+  - version
+tools:
+  - custom:
+      description: Custom module used to dump software versions within the nf-core pipeline template
+      homepage: https://github.com/nf-core/tools
+      documentation: https://github.com/nf-core/tools
+      licence: ["MIT"]
+input:
+  - versions:
+      type: file
+      description: YML file containing software versions
+      pattern: "*.yml"
+output:
+  - yml:
+      type: file
+      description: Standard YML file containing software versions
+      pattern: "software_versions.yml"
+  - mqc_yml:
+      type: file
+      description: MultiQC custom content YML file containing software versions
+      pattern: "software_versions_mqc.yml"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+authors:
+  - "@drpatelh"
+  - "@grst"
+maintainers:
+  - "@drpatelh"
+  - "@grst"

--- a/modules/nf-core/custom/dumpsoftwareversions/templates/dumpsoftwareversions.py
+++ b/modules/nf-core/custom/dumpsoftwareversions/templates/dumpsoftwareversions.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+
+
+"""Provide functions to merge multiple versions.yml files."""
+
+
+import yaml
+import platform
+from textwrap import dedent
+
+
+def _make_versions_html(versions):
+    """Generate a tabular HTML output of all versions for MultiQC."""
+    html = [
+        dedent(
+            """\\
+            <style>
+            #nf-core-versions tbody:nth-child(even) {
+                background-color: #f2f2f2;
+            }
+            </style>
+            <table class="table" style="width:100%" id="nf-core-versions">
+                <thead>
+                    <tr>
+                        <th> Process Name </th>
+                        <th> Software </th>
+                        <th> Version  </th>
+                    </tr>
+                </thead>
+            """
+        )
+    ]
+    for process, tmp_versions in sorted(versions.items()):
+        html.append("<tbody>")
+        for i, (tool, version) in enumerate(sorted(tmp_versions.items())):
+            html.append(
+                dedent(
+                    f"""\\
+                    <tr>
+                        <td><samp>{process if (i == 0) else ''}</samp></td>
+                        <td><samp>{tool}</samp></td>
+                        <td><samp>{version}</samp></td>
+                    </tr>
+                    """
+                )
+            )
+        html.append("</tbody>")
+    html.append("</table>")
+    return "\\n".join(html)
+
+
+def main():
+    """Load all version files and generate merged output."""
+    versions_this_module = {}
+    versions_this_module["${task.process}"] = {
+        "python": platform.python_version(),
+        "yaml": yaml.__version__,
+    }
+
+    with open("$versions") as f:
+        versions_by_process = yaml.load(f, Loader=yaml.BaseLoader) | versions_this_module
+
+    # aggregate versions by the module name (derived from fully-qualified process name)
+    versions_by_module = {}
+    for process, process_versions in versions_by_process.items():
+        module = process.split(":")[-1]
+        try:
+            if versions_by_module[module] != process_versions:
+                raise AssertionError(
+                    "We assume that software versions are the same between all modules. "
+                    "If you see this error-message it means you discovered an edge-case "
+                    "and should open an issue in nf-core/tools. "
+                )
+        except KeyError:
+            versions_by_module[module] = process_versions
+
+    versions_by_module["Workflow"] = {
+        "Nextflow": "$workflow.nextflow.version",
+        "$workflow.manifest.name": "$workflow.manifest.version",
+    }
+
+    versions_mqc = {
+        "id": "software_versions",
+        "section_name": "${workflow.manifest.name} Software Versions",
+        "section_href": "https://github.com/${workflow.manifest.name}",
+        "plot_type": "html",
+        "description": "are collected at run time from the software output.",
+        "data": _make_versions_html(versions_by_module),
+    }
+
+    with open("software_versions.yml", "w") as f:
+        yaml.dump(versions_by_module, f, default_flow_style=False)
+    with open("software_versions_mqc.yml", "w") as f:
+        yaml.dump(versions_mqc, f, default_flow_style=False)
+
+    with open("versions.yml", "w") as f:
+        yaml.dump(versions_this_module, f, default_flow_style=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/nf-core/custom/dumpsoftwareversions/tests/main.nf.test
+++ b/modules/nf-core/custom/dumpsoftwareversions/tests/main.nf.test
@@ -1,0 +1,43 @@
+nextflow_process {
+
+    name "Test Process CUSTOM_DUMPSOFTWAREVERSIONS"
+    script "../main.nf"
+    process "CUSTOM_DUMPSOFTWAREVERSIONS"
+    tag "modules"
+    tag "modules_nfcore"
+    tag "custom"
+    tag "dumpsoftwareversions"
+    tag "custom/dumpsoftwareversions"
+
+    test("Should run without failures") {
+        when {
+            process {
+                """
+                def tool1_version = '''
+                TOOL1:
+                    tool1: 0.11.9
+                '''.stripIndent()
+
+                def tool2_version = '''
+                TOOL2:
+                    tool2: 1.9
+                '''.stripIndent()
+
+                input[0] = Channel.of(tool1_version, tool2_version).collectFile()
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.versions,
+                    file(process.out.mqc_yml[0]).readLines()[0..10],
+                    file(process.out.yml[0]).readLines()[0..7]
+                    ).match()
+                }
+            )
+        }
+    }
+}

--- a/modules/nf-core/custom/dumpsoftwareversions/tests/main.nf.test.snap
+++ b/modules/nf-core/custom/dumpsoftwareversions/tests/main.nf.test.snap
@@ -1,0 +1,33 @@
+{
+    "Should run without failures": {
+        "content": [
+            [
+                "versions.yml:md5,76d454d92244589d32455833f7c1ba6d"
+            ],
+            [
+                "data: \"<style>\\n#nf-core-versions tbody:nth-child(even) {\\n    background-color: #f2f2f2;\\n\\",
+                "  }\\n</style>\\n<table class=\\\"table\\\" style=\\\"width:100%\\\" id=\\\"nf-core-versions\\\"\\",
+                "  >\\n    <thead>\\n        <tr>\\n            <th> Process Name </th>\\n            <th>\\",
+                "  \\ Software </th>\\n            <th> Version  </th>\\n        </tr>\\n    </thead>\\n\\",
+                "  \\n<tbody>\\n<tr>\\n    <td><samp>CUSTOM_DUMPSOFTWAREVERSIONS</samp></td>\\n    <td><samp>python</samp></td>\\n\\",
+                "  \\    <td><samp>3.11.7</samp></td>\\n</tr>\\n\\n<tr>\\n    <td><samp></samp></td>\\n \\",
+                "  \\   <td><samp>yaml</samp></td>\\n    <td><samp>5.4.1</samp></td>\\n</tr>\\n\\n</tbody>\\n\\",
+                "  <tbody>\\n<tr>\\n    <td><samp>TOOL1</samp></td>\\n    <td><samp>tool1</samp></td>\\n\\",
+                "  \\    <td><samp>0.11.9</samp></td>\\n</tr>\\n\\n</tbody>\\n<tbody>\\n<tr>\\n    <td><samp>TOOL2</samp></td>\\n\\",
+                "  \\    <td><samp>tool2</samp></td>\\n    <td><samp>1.9</samp></td>\\n</tr>\\n\\n</tbody>\\n\\",
+                "  <tbody>\\n<tr>\\n    <td><samp>Workflow</samp></td>\\n    <td><samp>Nextflow</samp></td>\\n\\"
+            ],
+            [
+                "CUSTOM_DUMPSOFTWAREVERSIONS:",
+                "  python: 3.11.7",
+                "  yaml: 5.4.1",
+                "TOOL1:",
+                "  tool1: 0.11.9",
+                "TOOL2:",
+                "  tool2: '1.9'",
+                "Workflow:"
+            ]
+        ],
+        "timestamp": "2024-01-09T23:01:18.710682"
+    }
+}

--- a/modules/nf-core/custom/dumpsoftwareversions/tests/tags.yml
+++ b/modules/nf-core/custom/dumpsoftwareversions/tests/tags.yml
@@ -1,0 +1,2 @@
+custom/dumpsoftwareversions:
+  - modules/nf-core/custom/dumpsoftwareversions/**

--- a/modules/nf-core/gunzip/environment.yml
+++ b/modules/nf-core/gunzip/environment.yml
@@ -1,0 +1,7 @@
+name: gunzip
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - conda-forge::sed=4.7

--- a/modules/nf-core/gunzip/main.nf
+++ b/modules/nf-core/gunzip/main.nf
@@ -1,0 +1,48 @@
+process GUNZIP {
+    tag "$archive"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/ubuntu:20.04' :
+        'nf-core/ubuntu:20.04' }"
+
+    input:
+    tuple val(meta), path(archive)
+
+    output:
+    tuple val(meta), path("$gunzip"), emit: gunzip
+    path "versions.yml"             , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    gunzip = archive.toString() - '.gz'
+    """
+    # Not calling gunzip itself because it creates files
+    # with the original group ownership rather than the
+    # default one for that user / the work directory
+    gzip \\
+        -cd \\
+        $args \\
+        $archive \\
+        > $gunzip
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        gunzip: \$(echo \$(gunzip --version 2>&1) | sed 's/^.*(gzip) //; s/ Copyright.*\$//')
+    END_VERSIONS
+    """
+
+    stub:
+    gunzip = archive.toString() - '.gz'
+    """
+    touch $gunzip
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        gunzip: \$(echo \$(gunzip --version 2>&1) | sed 's/^.*(gzip) //; s/ Copyright.*\$//')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/gunzip/meta.yml
+++ b/modules/nf-core/gunzip/meta.yml
@@ -1,0 +1,39 @@
+name: gunzip
+description: Compresses and decompresses files.
+keywords:
+  - gunzip
+  - compression
+  - decompression
+tools:
+  - gunzip:
+      description: |
+        gzip is a file format and a software application used for file compression and decompression.
+      documentation: https://www.gnu.org/software/gzip/manual/gzip.html
+      licence: ["GPL-3.0-or-later"]
+input:
+  - meta:
+      type: map
+      description: |
+        Optional groovy Map containing meta information
+        e.g. [ id:'test', single_end:false ]
+  - archive:
+      type: file
+      description: File to be compressed/uncompressed
+      pattern: "*.*"
+output:
+  - gunzip:
+      type: file
+      description: Compressed/uncompressed file
+      pattern: "*.*"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+authors:
+  - "@joseespinosa"
+  - "@drpatelh"
+  - "@jfy133"
+maintainers:
+  - "@joseespinosa"
+  - "@drpatelh"
+  - "@jfy133"

--- a/modules/nf-core/gunzip/tests/main.nf.test
+++ b/modules/nf-core/gunzip/tests/main.nf.test
@@ -1,0 +1,36 @@
+nextflow_process {
+
+    name "Test Process GUNZIP"
+    script "../main.nf"
+    process "GUNZIP"
+    tag "gunzip"
+    tag "modules_nfcore"
+    tag "modules"
+
+    test("Should run without failures") {
+
+        when {
+            params {
+                outdir = "$outputDir"
+            }
+            process {
+                """
+                input[0] = Channel.of([
+                        [],
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                    ]
+                )
+                """
+            }
+        }
+
+        then {
+            assertAll(
+            { assert process.success },
+            { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/gunzip/tests/main.nf.test.snap
+++ b/modules/nf-core/gunzip/tests/main.nf.test.snap
@@ -1,0 +1,31 @@
+{
+    "Should run without failures": {
+        "content": [
+            {
+                "0": [
+                    [
+                        [
+                            
+                        ],
+                        "test_1.fastq:md5,4161df271f9bfcd25d5845a1e220dbec"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,54376d32aca20e937a4ec26dac228e84"
+                ],
+                "gunzip": [
+                    [
+                        [
+                            
+                        ],
+                        "test_1.fastq:md5,4161df271f9bfcd25d5845a1e220dbec"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,54376d32aca20e937a4ec26dac228e84"
+                ]
+            }
+        ],
+        "timestamp": "2023-10-17T15:35:37.690477896"
+    }
+}

--- a/modules/nf-core/gunzip/tests/tags.yml
+++ b/modules/nf-core/gunzip/tests/tags.yml
@@ -1,0 +1,2 @@
+gunzip:
+  - modules/nf-core/gunzip/**

--- a/modules/nf-core/ltrfinder/environment.yml
+++ b/modules/nf-core/ltrfinder/environment.yml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+name: "ltrfinder"
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - "bioconda::ltr_finder_parallel=1.1"

--- a/modules/nf-core/ltrfinder/main.nf
+++ b/modules/nf-core/ltrfinder/main.nf
@@ -1,0 +1,53 @@
+process LTRFINDER {
+    tag "$meta.id"
+    label 'process_high'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/ltr_finder_parallel:1.1--hdfd78af_0':
+        'biocontainers/ltr_finder_parallel:1.1--hdfd78af_0' }"
+
+    input:
+    tuple val(meta), path(fasta)
+
+    output:
+    tuple val(meta), path("*.scn")      , emit: scn
+    tuple val(meta), path("*.gff3")     , emit: gff
+    path "versions.yml"                 , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args            = task.ext.args ?: ''
+    def prefix          = task.ext.prefix ?: "${meta.id}"
+    """
+    LTR_FINDER_parallel \\
+        -seq $fasta \\
+        -threads $task.cpus \\
+        $args
+
+    mv "${fasta}.finder.combine.scn"    "${prefix}.scn"
+    mv "${fasta}.finder.combine.gff3"   "${prefix}.gff3"
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        LTR_FINDER_parallel: \$(LTR_FINDER_parallel -h | grep 'Version:' | sed 's/Version: //')
+        ltr_finder: \$(ltr_finder -h 2>&1 | grep 'ltr_finder' | sed 's/ltr_finder //')
+    END_VERSIONS
+    """
+
+    stub:
+    def args            = task.ext.args ?: ''
+    def prefix          = task.ext.prefix ?: "${meta.id}"
+    """
+    touch "${prefix}.scn"
+    touch "${prefix}.gff3"
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        LTR_FINDER_parallel: \$(LTR_FINDER_parallel -h | grep 'Version:' | sed 's/Version: //')
+        ltr_finder: \$(ltr_finder -h 2>&1 | grep 'ltr_finder' | sed 's/ltr_finder //')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/ltrfinder/meta.yml
+++ b/modules/nf-core/ltrfinder/meta.yml
@@ -1,0 +1,60 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "ltrfinder"
+description: |
+  Finds full-length LTR retrotranspsons in genome sequences using the
+  parallel version of LTR_Finder
+keywords:
+  - genomics
+  - annotation
+  - parallel
+  - repeat
+  - long terminal retrotransposon
+  - retrotransposon
+tools:
+  - "LTR_FINDER_parallel":
+      description: A Perl wrapper for LTR_FINDER
+      homepage: "https://github.com/oushujun/LTR_FINDER_parallel"
+      documentation: "https://github.com/oushujun/LTR_FINDER_parallel"
+      tool_dev_url: "https://github.com/oushujun/LTR_FINDER_parallel"
+      doi: "10.1186/s13100-019-0193-0"
+      licence: ["MIT"]
+  - "LTR_Finder":
+      description: An efficient program for finding full-length LTR retrotranspsons in genome sequences
+      homepage: "https://github.com/xzhub/LTR_Finder"
+      documentation: "https://github.com/xzhub/LTR_Finder"
+      tool_dev_url: "https://github.com/xzhub/LTR_Finder"
+      doi: "10.1093/nar/gkm286"
+      licence: ["MIT"]
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. `[ id:'sample1' ]`
+  - fasta:
+      type: file
+      description: Genome sequences in fasta format
+      pattern: "*.{fsa,fa,fasta}"
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. `[ id:'sample1' ]`
+  - scn:
+      type: file
+      description: Annotation in LTRharvest or LTR_FINDER format
+      pattern: "*.scn"
+  - gff:
+      type: file
+      description: Annotation in gff3 format
+      pattern: "*.gff3"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+authors:
+  - "@GallVp"
+maintainers:
+  - "@GallVp"

--- a/modules/nf-core/ltrfinder/tests/main.nf.test
+++ b/modules/nf-core/ltrfinder/tests/main.nf.test
@@ -1,0 +1,72 @@
+nextflow_process {
+
+    name "Test Process LTRFINDER"
+    script "../main.nf"
+    process "LTRFINDER"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "ltrfinder"
+    tag "gunzip/main"
+
+    test("actinidia_chinensis-genome_21_fasta_gz-success") {
+
+        setup {
+            run('GUNZIP') {
+                script "../../gunzip/main"
+
+                process {
+                    """
+                    input[0] = [
+                        [ id:'test' ], // meta map
+                        file(params.test_data['actinidia_chinensis']['genome']['genome_21_fasta_gz'], checkIfExists: true)
+                    ]
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = GUNZIP.out.gunzip
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() },
+                { assert snapshot(path(process.out.versions[0]).text).match("versions") }
+            )
+        }
+
+    }
+
+    test("stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.test_data['actinidia_chinensis']['genome']['genome_21_fasta_gz'], checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() },
+                { assert snapshot(path(process.out.versions[0]).text).match("stub_versions") }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/ltrfinder/tests/main.nf.test.snap
+++ b/modules/nf-core/ltrfinder/tests/main.nf.test.snap
@@ -1,0 +1,120 @@
+{
+    "actinidia_chinensis-genome_21_fasta_gz-success": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.scn:md5,006193c9eaf3f552ccb0369f159e7660"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.gff3:md5,96e5305163939e4381e1b94b660dc0a2"
+                    ]
+                ],
+                "2": [
+                    "versions.yml:md5,7b24225b810fa88cfb2a887de11be333"
+                ],
+                "gff": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.gff3:md5,96e5305163939e4381e1b94b660dc0a2"
+                    ]
+                ],
+                "scn": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.scn:md5,006193c9eaf3f552ccb0369f159e7660"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,7b24225b810fa88cfb2a887de11be333"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-02-16T09:14:38.509965"
+    },
+    "versions": {
+        "content": [
+            "\"LTRFINDER\":\n    LTR_FINDER_parallel: v1.1\n    ltr_finder: v1.07\n"
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-02-16T09:16:55.301422"
+    },
+    "stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.scn:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.gff3:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    "versions.yml:md5,7b24225b810fa88cfb2a887de11be333"
+                ],
+                "gff": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.gff3:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "scn": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.scn:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,7b24225b810fa88cfb2a887de11be333"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-02-16T09:14:43.054758"
+    },
+    "stub_versions": {
+        "content": [
+            "\"LTRFINDER\":\n    LTR_FINDER_parallel: v1.1\n    ltr_finder: v1.07\n"
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-02-16T09:16:59.800724"
+    }
+}

--- a/modules/nf-core/ltrfinder/tests/tags.yml
+++ b/modules/nf-core/ltrfinder/tests/tags.yml
@@ -1,0 +1,2 @@
+ltrfinder:
+  - "modules/nf-core/ltrfinder/**"

--- a/modules/nf-core/ltrharvest/environment.yml
+++ b/modules/nf-core/ltrharvest/environment.yml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+name: "ltrharvest"
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - "bioconda::ltr_harvest_parallel=1.1"

--- a/modules/nf-core/ltrharvest/main.nf
+++ b/modules/nf-core/ltrharvest/main.nf
@@ -1,0 +1,56 @@
+process LTRHARVEST {
+    tag "$meta.id"
+    label 'process_medium'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/ltr_harvest_parallel:1.1--hdfd78af_0':
+        'biocontainers/ltr_harvest_parallel:1.1--hdfd78af_0' }"
+
+    input:
+    tuple val(meta), path(fasta)
+
+    output:
+    tuple val(meta), path("*.gff3") , emit: gff3
+    tuple val(meta), path("*.scn")  , emit: scn
+    path "versions.yml"             , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    LTR_HARVEST_parallel \\
+        -seq $fasta \\
+        $args \\
+        -threads $task.cpus
+
+    mv "${fasta}.harvest.combine.gff3" \\
+        "${prefix}.gff3"
+
+    mv "${fasta}.harvest.combine.scn" \\
+        "${prefix}.scn"
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        LTR_HARVEST_parallel: \$(LTR_HARVEST_parallel -h | sed -n '/Version/s/Version: //p')
+        genometools: \$(gt --version | sed '1!d ; s/gt (GenomeTools) //')
+    END_VERSIONS
+    """
+
+    stub:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch "${prefix}.gff3"
+    touch "${prefix}.scn"
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        LTR_HARVEST_parallel: \$(LTR_HARVEST_parallel -h | sed -n '/Version/s/Version: //p')
+        genometools: \$(gt --version | sed '1!d ; s/gt (GenomeTools) //')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/ltrharvest/meta.yml
+++ b/modules/nf-core/ltrharvest/meta.yml
@@ -1,0 +1,59 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "ltrharvest"
+description: |
+  Predicts LTR retrotransposons using the parallel version of GenomeTools gt-ltrharvest
+  utility included in the EDTA toolchain
+keywords:
+  - genomics
+  - genome
+  - annotation
+  - repeat
+  - transposons
+  - retrotransposons
+tools:
+  - "LTR_HARVEST_parallel":
+      description: A Perl wrapper for LTR_harvest
+      homepage: "https://github.com/oushujun/EDTA/tree/v2.2.0/bin/LTR_HARVEST_parallel"
+      documentation: "https://github.com/oushujun/EDTA/tree/v2.2.0/bin/LTR_HARVEST_parallel"
+      tool_dev_url: "https://github.com/oushujun/EDTA/tree/v2.2.0/bin/LTR_HARVEST_parallel"
+      licence: ["MIT"]
+  - "gt":
+      description: "The GenomeTools genome analysis system"
+      homepage: "https://genometools.org/index.html"
+      documentation: "https://genometools.org/documentation.html"
+      tool_dev_url: "https://github.com/genometools/genometools"
+      doi: "10.1109/TCBB.2013.68"
+      licence: ["ISC"]
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. `[ id:'sample1' ]`
+  - fasta:
+      type: file
+      description: Input genome fasta
+      pattern: "*.{fsa,fa,fasta}"
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. `[ id:'sample1' ]`
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - gff3:
+      type: file
+      description: Predicted LTR candidates in gff3 format
+      pattern: "*.gff3"
+  - scn:
+      type: file
+      description: Predicted LTR candidates in scn format
+      pattern: "*.scn"
+authors:
+  - "@GallVp"
+maintainers:
+  - "@GallVp"

--- a/modules/nf-core/ltrharvest/tests/main.nf.test
+++ b/modules/nf-core/ltrharvest/tests/main.nf.test
@@ -1,0 +1,60 @@
+nextflow_process {
+
+    name "Test Process LTRHARVEST"
+    script "../main.nf"
+    process "LTRHARVEST"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "ltrharvest"
+
+    test("homo_sapiens-genome_21_fasta") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.test_data['homo_sapiens']['genome']['genome_21_fasta'], checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out.gff3).match("gff3") },
+                { assert path(process.out.scn[0][1]).text.contains("46510803 46520182 9380 46510803 46510940 138 46520042 46520182 141 86.52 0 chr21") },
+                { assert snapshot(path(process.out.versions[0]).text).match("script_versions") }
+            )
+        }
+
+    }
+
+    test("homo_sapiens-genome_fasta-stub") {
+
+        options '-stub'
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() },
+                { assert snapshot(path(process.out.versions[0]).text).match("stub_versions") }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/ltrharvest/tests/main.nf.test.snap
+++ b/modules/nf-core/ltrharvest/tests/main.nf.test.snap
@@ -1,0 +1,88 @@
+{
+    "homo_sapiens-genome_fasta-stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.gff3:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.scn:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    "versions.yml:md5,51e82185b713482d1d48b6f15abe7fcc"
+                ],
+                "gff3": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.gff3:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "scn": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.scn:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,51e82185b713482d1d48b6f15abe7fcc"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-02-22T14:44:30.682167"
+    },
+    "script_versions": {
+        "content": [
+            "\"LTRHARVEST\":\n    LTR_HARVEST_parallel: v1.1\n    genometools: 1.6.5\n"
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-02-22T14:44:26.672478"
+    },
+    "gff3": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.gff3:md5,da13c4ba22e44ef944ddec38aa72c468"
+                ]
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-02-22T19:29:33.962761"
+    },
+    "stub_versions": {
+        "content": [
+            "\"LTRHARVEST\":\n    LTR_HARVEST_parallel: v1.1\n    genometools: 1.6.5\n"
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-02-22T14:44:30.729166"
+    }
+}

--- a/modules/nf-core/ltrharvest/tests/tags.yml
+++ b/modules/nf-core/ltrharvest/tests/tags.yml
@@ -1,0 +1,2 @@
+ltrharvest:
+  - "modules/nf-core/ltrharvest/**"

--- a/modules/nf-core/ltrretriever/ltrretriever/environment.yml
+++ b/modules/nf-core/ltrretriever/ltrretriever/environment.yml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+name: "ltrretriever_ltrretriever"
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - "bioconda::LTR_retriever=2.9.9"

--- a/modules/nf-core/ltrretriever/ltrretriever/main.nf
+++ b/modules/nf-core/ltrretriever/ltrretriever/main.nf
@@ -1,0 +1,77 @@
+process LTRRETRIEVER_LTRRETRIEVER {
+    tag "$meta.id"
+    label 'process_high'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/ltr_retriever:2.9.9--hdfd78af_0':
+        'biocontainers/ltr_retriever:2.9.9--hdfd78af_0' }"
+
+    input:
+    tuple val(meta), path(genome)
+    path(harvest)
+    path(finder)
+    path(mgescan)
+    path(non_tgca)
+
+    output:
+    tuple val(meta), path("*.log")              , emit: log
+    tuple val(meta), path("${prefix}.pass.list"), emit: pass_list
+    tuple val(meta), path("*.pass.list.gff3")   , emit: pass_list_gff
+    tuple val(meta), path("*.LTRlib.fa")        , emit: ltrlib
+    tuple val(meta), path("${prefix}.out")      , emit: annotation_out  , optional: true
+    tuple val(meta), path("*.out.gff3")         , emit: annotation_gff  , optional: true
+    path "versions.yml"                         , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args            = task.ext.args     ?: ''
+    prefix              = task.ext.prefix   ?: "${meta.id}"
+    def inharvest       = harvest           ? "-inharvest $harvest" : ''
+    def infinder        = finder            ? "-infinder $finder"   : ''
+    def inmgescan       = mgescan           ? "-inmgescan $mgescan" : ''
+    def non_tgca_file   = non_tgca          ? "-nonTGCA $non_tgca"  : ''
+    """
+    LTR_retriever \\
+        -genome $genome \\
+        $inharvest \\
+        $infinder \\
+        $inmgescan \\
+        $non_tgca_file \\
+        -threads $task.cpus \\
+        $args \\
+        &> >(tee "${prefix}.log" 2>&1)
+
+    mv "${genome}.pass.list"        "${prefix}.pass.list"
+    mv "${genome}.pass.list.gff3"   "${prefix}.pass.list.gff3"
+    mv "${genome}.LTRlib.fa"        "${prefix}.LTRlib.fa"
+    mv "${genome}.out"              "${prefix}.out"             || echo ".out was not produced"
+    mv "${genome}.out.gff3"         "${prefix}.out.gff3"        || echo ".out.gff3 was not produced"
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        LTR_retriever: \$(LTR_retriever -h 2>&1 | grep '### LTR_retriever' | sed 's/### LTR_retriever //; s/ ###//')
+    END_VERSIONS
+    """
+
+    stub:
+    def args            = task.ext.args             ?: ''
+    prefix              = task.ext.prefix           ?: "${meta.id}"
+    def touch_out       = args.contains('-noanno')  ? ''            : "touch ${prefix}.out"
+    def touch_out_gff   = args.contains('-noanno')  ? ''            : "touch ${prefix}.out.gff3"
+    """
+    touch "${prefix}.log"
+    touch "${prefix}.pass.list"
+    touch "${prefix}.pass.list.gff3"
+    touch "${prefix}.LTRlib.fa"
+    $touch_out
+    $touch_out_gff
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        LTR_retriever: \$(LTR_retriever -h 2>&1 | grep '### LTR_retriever' | sed 's/### LTR_retriever //; s/ ###//')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/ltrretriever/ltrretriever/meta.yml
+++ b/modules/nf-core/ltrretriever/ltrretriever/meta.yml
@@ -1,0 +1,83 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "ltrretriever_ltrretriever"
+description: Identifies LTR retrotransposons using LTR_retriever
+keywords:
+  - genomics
+  - annotation
+  - repeat
+  - long terminal repeat
+  - retrotransposon
+tools:
+  - "LTR_retriever":
+      description: Sensitive and accurate identification of LTR retrotransposons
+      homepage: "https://github.com/oushujun/LTR_retriever"
+      documentation: "https://github.com/oushujun/LTR_retriever"
+      tool_dev_url: "https://github.com/oushujun/LTR_retriever"
+      doi: "10.1104/pp.17.01310"
+      licence: ["GPL v3"]
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. `[ id:'sample1' ]`
+  - genome:
+      type: file
+      description: Genomic sequences in fasta format
+      pattern: "*.{fsa,fa,fasta}"
+  - harvest:
+      type: file
+      description: LTR-RT candidates from GenomeTools ltrharvest in the old tabular format
+      pattern: "*.tabout"
+  - finder:
+      type: file
+      description: LTR-RT candidates from LTR_FINDER
+      pattern: "*.scn"
+  - mgescan:
+      type: file
+      description: LTR-RT candidates from MGEScan_LTR
+      pattern: "*.out"
+  - non_tgca:
+      type: file
+      description: Non-canonical LTR-RT candidates from GenomeTools ltrharvest in the old tabular format
+      pattern: "*.tabout"
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. `[ id:'sample1' ]`
+  - log:
+      type: file
+      description: Output log from LTR_retriever
+      pattern: "*.log"
+  - pass_list:
+      type: file
+      description: Intact LTR-RTs with coordinate and structural information in summary table format
+      pattern: "*.pass.list"
+  - pass_list_gff:
+      type: file
+      description: Intact LTR-RTs with coordinate and structural information in gff3 format
+      pattern: "*.pass.list.gff3"
+  - ltrlib:
+      type: file
+      description: All non-redundant LTR-RTs
+      pattern: "*.LTRlib.fa"
+  - annotation_out:
+      type: file
+      description: Whole-genome LTR-RT annotation by the non-redundant library
+      pattern: "*.out"
+  - annotation_gff:
+      type: file
+      description: Whole-genome LTR-RT annotation by the non-redundant library in gff3 format
+      pattern: "*.out.gff3"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+
+authors:
+  - "@GallVp"
+maintainers:
+  - "@GallVp"

--- a/modules/nf-core/ltrretriever/ltrretriever/tests/main.nf.test
+++ b/modules/nf-core/ltrretriever/ltrretriever/tests/main.nf.test
@@ -1,0 +1,133 @@
+nextflow_process {
+
+    name "Test Process LTRRETRIEVER_LTRRETRIEVER"
+    script "../main.nf"
+    process "LTRRETRIEVER_LTRRETRIEVER"
+    config "./nextflow.config"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "ltrretriever"
+    tag "ltrretriever/ltrretriever"
+    tag "gunzip/main"
+    tag "gt/ltrharvest"
+    tag "gt/suffixerator"
+    tag "ltrfinder"
+    tag "cat/cat"
+
+    test("actinidia_chinensis-genome_21_fasta_gz-success") {
+
+        setup {
+
+            run('GUNZIP') {
+                script "../../../gunzip/main"
+
+                process {
+                    """
+                    input[0] = [
+                        [ id:'test' ], // meta map
+                        file(params.test_data['actinidia_chinensis']['genome']['genome_21_fasta_gz'], checkIfExists: true)
+                    ]
+                    """
+                }
+            }
+
+            run("GT_SUFFIXERATOR") {
+                script "../../../gt/suffixerator"
+
+                process {
+                    """
+                    input[0] = GUNZIP.out.gunzip
+                    input[1] = 'dna'
+                    """
+                }
+            }
+
+            run("GT_LTRHARVEST") {
+                script "../../../gt/ltrharvest"
+
+                process {
+                    """
+                    input[0] = GT_SUFFIXERATOR.out.index
+                    """
+                }
+            }
+
+            run("LTRFINDER") {
+                script "../../../ltrfinder"
+
+                process {
+                    """
+                    input[0] = GUNZIP.out.gunzip
+                    """
+                }
+            }
+
+            run("CAT_CAT") {
+                script "../../../cat/cat"
+
+                process {
+                    """
+                    input[0] = GT_LTRHARVEST.out.tabout.mix(LTRFINDER.out.scn).groupTuple()
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = GUNZIP.out.gunzip
+                input[1] = CAT_CAT.out.file_out.map { meta, tabout -> tabout }
+                input[2] = []
+                input[3] = []
+                input[4] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.log[0][1]).text.contains("####### Result files #########") },
+                { assert snapshot(process.out.pass_list).match("pass_list") },
+                { assert path(process.out.pass_list_gff[0][1]).text.contains("chr1\tLTR_retriever\ttarget_site_duplication") },
+                { assert path(process.out.ltrlib[0][1]).text.contains("LTR#LTR/Copia") },
+                { assert snapshot(process.out.annotation_out).match("annotation_out") },
+                { assert path(process.out.annotation_gff[0][1]).text.contains("Classification=LTR/Copia") },
+                { assert snapshot(path(process.out.versions[0]).text).match("versions") }
+            )
+        }
+
+    }
+
+    test("stub") {
+
+        options '-stub'
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.test_data['actinidia_chinensis']['genome']['genome_21_fasta_gz'], checkIfExists: true)
+                ]
+                input[1] = []
+                input[2] = []
+                input[3] = []
+                input[4] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() },
+                { assert snapshot(path(process.out.versions[0]).text).match("versions_stub") }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/ltrretriever/ltrretriever/tests/main.nf.test.snap
+++ b/modules/nf-core/ltrretriever/ltrretriever/tests/main.nf.test.snap
@@ -1,0 +1,169 @@
+{
+    "versions_stub": {
+        "content": [
+            "\"LTRRETRIEVER_LTRRETRIEVER\":\n    LTR_retriever: v2.9.9\n"
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-02-19T11:04:16.007262"
+    },
+    "pass_list": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.pass.list:md5,0c96ee3b48691e65da2235786a926160"
+                ]
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-02-19T11:17:50.087449"
+    },
+    "versions": {
+        "content": [
+            "\"LTRRETRIEVER_LTRRETRIEVER\":\n    LTR_retriever: v2.9.9\n"
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-02-19T11:17:50.208819"
+    },
+    "stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.pass.list:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.pass.list.gff3:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.LTRlib.fa:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "4": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.out:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "5": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.out.gff3:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "6": [
+                    "versions.yml:md5,3ab159acaee06b342b56e2d35e5e669b"
+                ],
+                "annotation_gff": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.out.gff3:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "annotation_out": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.out:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "ltrlib": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.LTRlib.fa:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "pass_list": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.pass.list:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "pass_list_gff": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.pass.list.gff3:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,3ab159acaee06b342b56e2d35e5e669b"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-02-19T11:04:15.954424"
+    },
+    "annotation_out": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.out:md5,4ecf9226cbd7a3aaf7cf5cfa575fcc6a"
+                ]
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-02-19T11:17:50.150622"
+    }
+}

--- a/modules/nf-core/ltrretriever/ltrretriever/tests/nextflow.config
+++ b/modules/nf-core/ltrretriever/ltrretriever/tests/nextflow.config
@@ -1,0 +1,21 @@
+process {
+
+    withName: GT_SUFFIXERATOR {
+        ext.args = '-suf -lcp'
+        // GT_LTRHARVEST requires -suf, -lcp
+    }
+
+    withName: LTRFINDER {
+        ext.args = '-harvest_out'
+        // LTRRETRIEVER requires -harvest_out
+    }
+
+    withName: GT_LTRHARVEST {
+        ext.args = '-minlenltr 100 -maxlenltr 7000 -mintsd 4 -maxtsd 6 -motif TGCA -motifmis 1 -similar 85 -vic 10 -seed 20 -seqids yes'
+        // recommended parameters: https://github.com/oushujun/LTR_retriever#usage
+    }
+
+    withName: CAT_CAT {
+        ext.prefix = { "${meta.id}_ltrharvest_ltrfinder.tabout" }
+    }
+}

--- a/modules/nf-core/ltrretriever/ltrretriever/tests/tags.yml
+++ b/modules/nf-core/ltrretriever/ltrretriever/tests/tags.yml
@@ -1,0 +1,2 @@
+ltrretriever/ltrretriever:
+  - "modules/nf-core/ltrretriever/ltrretriever/**"

--- a/modules/pfr/custom/restoregffids/environment.yml
+++ b/modules/pfr/custom/restoregffids/environment.yml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+name: "custom_restoregffids"
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - "python=3.10.2"

--- a/modules/pfr/custom/restoregffids/main.nf
+++ b/modules/pfr/custom/restoregffids/main.nf
@@ -1,0 +1,35 @@
+process CUSTOM_RESTOREGFFIDS {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/python:3.10.2':
+        'biocontainers/python:3.10.2' }"
+
+    input:
+    tuple val(meta), path(gff3)
+    path(ids_tsv)
+
+    output:
+    tuple val(meta), path("*.restored.ids.gff3")    , emit: restored_ids_gff3
+    path "versions.yml"                             , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    prefix = task.ext.prefix ?: "${meta.id}"
+    template 'restore_gff_ids.py'
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch "${prefix}.restored.ids.gff3"
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        python: \$(python --version | cut -d' ' -f2)
+    END_VERSIONS
+    """
+}

--- a/modules/pfr/custom/restoregffids/meta.yml
+++ b/modules/pfr/custom/restoregffids/meta.yml
@@ -1,0 +1,58 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "custom_restoregffids"
+description: |
+  Restores IDs in a gff3 file based on a TSV table
+  consisting of original (first column) and new IDs (second column).
+  This module is helpful when some tools like EDTA implicitly shorten
+  the IDs without producing the ID map, leading to downstream mismatch
+  in IDs across files.
+keywords:
+  - genome
+  - gff
+  - ID
+  - shorten
+  - restore
+tools:
+  - "python":
+      description: |
+        Python is a programming language that lets you work quickly
+        and integrate systems more effectively
+      homepage: "https://www.python.org"
+      documentation: "https://docs.python.org/3/"
+      tool_dev_url: "https://github.com/python/cpython"
+      licence: ["MIT"]
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. `[ id:'test' ]`
+  - gff3:
+      type: file
+      description: Input gff3 file
+      pattern: "*.{gff,gff3}"
+  - ids_tsv:
+      type: file
+      description: |
+        A TSV file with original (first column) and new ids (second column)
+        if id change was required
+      pattern: "*.tsv"
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. `[ id:'test' ]`
+  - restored_ids_gff3:
+      type: file
+      description: GFF3 file with restored ids
+      pattern: "*.restored.ids.gff3"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+authors:
+  - "@GallVp"
+maintainers:
+  - "@GallVp"

--- a/modules/pfr/custom/restoregffids/templates/restore_gff_ids.py
+++ b/modules/pfr/custom/restoregffids/templates/restore_gff_ids.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+from platform import python_version
+
+ids_tsv = "$ids_tsv"
+input_gff3 = "$gff3"
+output_prefix = "$prefix"
+
+
+def create_name_mapping_from_tsv(file_path):
+    dictionary = {}
+
+    with open(file_path, "r") as tsv_file:
+        for line in tsv_file:
+            columns = line.strip().split("\\t")
+            if len(columns) != 2:
+                raise ValueError(f"{file_path} should be a two column TSV file")
+
+            orig_id, new_id = columns[0], columns[1]
+            dictionary[new_id] = orig_id
+
+    return dictionary
+
+
+def restore_gff3_ids(new_to_orig_ids, file_path, output_file_name):
+    # Write versions
+    with open(f"versions.yml", "w") as f_versions:
+        f_versions.write('"${task.process}":\\n')
+        f_versions.write(f"    python: {python_version()}\\n")
+
+    with open(file_path, "r") as input_gff3_file:
+        input_lines = input_gff3_file.readlines()
+
+    with open(output_file_name, "w") as output_gff_file:
+        for line in input_lines:
+            if line.startswith("##"):
+                output_gff_file.write(line)
+                continue
+
+            new_id = line.split("\\t")[0]
+            orig_id = new_to_orig_ids[new_id]
+            output_gff_file.write("\\t".join([orig_id] + line.split("\\t")[1:]))
+
+
+if __name__ == "__main__":
+    new_to_orig_ids = create_name_mapping_from_tsv(ids_tsv)
+    restore_gff3_ids(new_to_orig_ids, input_gff3, f"{output_prefix}.restored.ids.gff3")

--- a/modules/pfr/custom/restoregffids/tests/main.nf.test
+++ b/modules/pfr/custom/restoregffids/tests/main.nf.test
@@ -1,0 +1,63 @@
+nextflow_process {
+
+    name "Test Process CUSTOM_RESTOREGFFIDS"
+    script "../main.nf"
+    process "CUSTOM_RESTOREGFFIDS"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "custom"
+    tag "custom/restoregffids"
+
+    test("sarscov2-genome_gff3-success") {
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.test_data['sarscov2']['genome']['genome_gff3'], checkIfExists: true)
+                ]
+                input[1] = Channel.of('Chr1\tMT192765.1').collectFile(name: 'id_map.tsv', newLine: true)
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() },
+                { assert path(process.out.restored_ids_gff3.get(0).get(1)).getText().contains("Chr1") },
+                { assert !path(process.out.restored_ids_gff3.get(0).get(1)).getText().contains("MT192765.1") },
+                { assert snapshot(process.out.versions).match("versions") }
+            )
+        }
+
+    }
+
+    test("stub") {
+
+        options '-stub'
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.test_data['sarscov2']['genome']['genome_gff3'], checkIfExists: true)
+                ]
+                input[1] = Channel.of('Chr1\tMT192765.1').collectFile(name: 'id_map.tsv', newLine: true)
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.restored_ids_gff3 != null },
+                { assert snapshot(process.out.versions).match("versions") }
+            )
+        }
+
+    }
+
+}

--- a/modules/pfr/custom/restoregffids/tests/main.nf.test.snap
+++ b/modules/pfr/custom/restoregffids/tests/main.nf.test.snap
@@ -1,0 +1,41 @@
+{
+    "sarscov2-genome_gff3-success": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.restored.ids.gff3:md5,2c294938b9eb4e52d19e14725c1d92a9"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,32d31c4f1da9a3d1be013fd163e5867e"
+                ],
+                "restored_ids_gff3": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.restored.ids.gff3:md5,2c294938b9eb4e52d19e14725c1d92a9"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,32d31c4f1da9a3d1be013fd163e5867e"
+                ]
+            }
+        ],
+        "timestamp": "2023-12-07T13:49:30.047425"
+    },
+    "versions": {
+        "content": [
+            [
+                "versions.yml:md5,32d31c4f1da9a3d1be013fd163e5867e"
+            ]
+        ],
+        "timestamp": "2023-12-07T13:49:30.071175"
+    }
+}

--- a/modules/pfr/custom/restoregffids/tests/tags.yml
+++ b/modules/pfr/custom/restoregffids/tests/tags.yml
@@ -1,0 +1,2 @@
+custom/restoregffids:
+  - "modules/pfr/custom/restoregffids/**"

--- a/modules/pfr/custom/shortenfastaids/environment.yml
+++ b/modules/pfr/custom/shortenfastaids/environment.yml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+name: "custom_shortenfastaids"
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+
+dependencies:
+  - biopython==1.75
+  - python=3.8

--- a/modules/pfr/custom/shortenfastaids/main.nf
+++ b/modules/pfr/custom/shortenfastaids/main.nf
@@ -1,0 +1,34 @@
+process CUSTOM_SHORTENFASTAIDS {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/biopython:1.75':
+        'biocontainers/biopython:1.75' }"
+
+    input:
+    tuple val(meta), path(fasta)
+
+    output:
+    tuple val(meta), path("*.short.ids.fasta")  , emit: short_ids_fasta , optional: true
+    tuple val(meta), path("*.short.ids.tsv")    , emit: short_ids_tsv   , optional: true
+    path "versions.yml"                         , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    prefix = task.ext.prefix ?: "${meta.id}"
+    template 'shorten_fasta_ids.py'
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        python: \$(python --version | cut -d' ' -f2)
+        biopython: \$(pip list | grep "biopython" | cut -d' ' -f3)
+    END_VERSIONS
+    """
+}

--- a/modules/pfr/custom/shortenfastaids/meta.yml
+++ b/modules/pfr/custom/shortenfastaids/meta.yml
@@ -1,0 +1,58 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "custom_shortenfastaids"
+description: |
+  Shortens fasta IDs and produces a new fasta along with a TSV table
+  consisting of original (first column) and new IDs (second column).
+  This module is helpful when some tools like EDTA implicitly shorten
+  the IDs without producing the ID map, leading to downstream mismatch
+  in IDs across files.
+keywords:
+  - genome
+  - fasta
+  - ID
+  - shorten
+tools:
+  - "biopython":
+      description: |
+        Biopython is a set of freely available tools for biological computation written in Python by
+        an international team of developers.
+      homepage: "https://biopython.org"
+      documentation: "https://biopython.org/wiki/Documentation"
+      tool_dev_url: "https://github.com/biopython/biopython"
+      doi: "10.1093/bioinformatics/btp163"
+      licence: ["MIT"]
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. `[ id:'test' ]`
+  - fasta:
+      type: file
+      description: Input fasta file
+      pattern: "*.{fsa,fa,fasta}"
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. `[ id:'test' ]`
+  - short_ids_fasta:
+      type: file
+      description: Fasta file with shortened ids if id change is required
+      pattern: "*.{fsa,fa,fasta}"
+  - short_ids_tsv:
+      type: file
+      description: |
+        A TSV file with original (first column) and new ids (second column)
+        if id change is required
+      pattern: "*.tsv"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+authors:
+  - "@GallVp"
+maintainers:
+  - "@GallVp"

--- a/modules/pfr/custom/shortenfastaids/templates/shorten_fasta_ids.py
+++ b/modules/pfr/custom/shortenfastaids/templates/shorten_fasta_ids.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+
+import re
+
+from Bio import SeqIO
+from importlib.metadata import version
+from platform import python_version
+
+# The input fasta file path
+fasta_file_path = "$fasta"
+output_files_prefix = "$prefix"
+
+
+def extract_fasta_ids_and_descriptions(fasta_file_path):
+    fasta_file_obj = SeqIO.parse(fasta_file_path, "fasta")
+
+    ids = []
+    for record in fasta_file_obj:
+        ids.append((record.id, record.description))
+    return ids
+
+
+def write_fasta_with_new_ids(fasta_file_path, id_mapping, file_prefix):
+    old_fasta_file_obj = SeqIO.parse(fasta_file_path, "fasta")
+    id_map = dict(id_mapping)
+
+    replaced_records = []
+    for record in old_fasta_file_obj:
+        old_id = record.id
+
+        new_id = id_map[old_id]
+        record.id = new_id
+        record.description = ""
+
+        replaced_records.append(record)
+
+    SeqIO.write(replaced_records, f"{file_prefix}.short.ids.fasta", "fasta")
+
+
+def do_id_need_to_change(id_and_description, silent=False):
+    id = id_and_description[0]
+    description = id_and_description[1]
+    if len(id) > 13:
+        if not silent:
+            print(f"{id} has length greater than 13")
+        return True
+
+    if not re.match(r"^[a-zA-Z0-9_]+\$", id):
+        if not silent:
+            print(f"{id} does not match '^[a-zA-Z0-9_]+\$'")
+        return True
+
+    if description != id and description != "":
+        if not silent:
+            print(f"{id} contains a comment: {description.replace(id, '')}")
+        return True
+
+    if not silent:
+        print(f"{id} is acceptable")
+    return False
+
+
+def do_ids_need_to_change(ids_and_descriptions, silent=False):
+    return any(
+        [
+            do_id_need_to_change(id_and_description, silent)
+            for id_and_description in ids_and_descriptions
+        ]
+    )
+
+
+def extract_common_patterns(ids):
+    pattern_counts = {}
+    for id in ids:
+        patterns = re.findall(r"[A-Za-z0_]{4,}", id)
+        for pattern in set(patterns):
+            pattern_counts[pattern] = pattern_counts.get(pattern, 0) + 1
+
+    common_patterns = [
+        pattern for pattern, count in pattern_counts.items() if count >= 2
+    ]
+
+    if len(common_patterns) < 1:
+        return {}
+
+    return {pattern: pattern[:3] for pattern in common_patterns}
+
+
+def shorten_ids(input_ids_and_descriptions, patterns_dict):
+    shortened_ids = []
+
+    for id_and_description in input_ids_and_descriptions:
+        id = id_and_description[0]
+        description = ""  # Treat description as absent as it will be removed by write_fasta_with_new_ids
+        if not do_id_need_to_change((id, description), silent=True):
+            shortened_ids.append(id)
+            continue
+
+        shortened_id = shorten_id_by_pattern_replacement(patterns_dict, id)
+
+        if not do_id_need_to_change((shortened_id, description), silent=True):
+            shortened_ids.append(shortened_id)
+            continue
+
+        shortened_id = f"Ctg{generate_hash(id)}"
+
+        if not do_id_need_to_change((shortened_id, description), silent=True):
+            shortened_ids.append(shortened_id)
+            continue
+
+        raise ValueError(f"Failed to shorten id: {id} ({shortened_id})")
+
+    return shortened_ids
+
+
+def shorten_id_by_pattern_replacement(patterns_dict, id):
+    if patterns_dict == {}:
+        return id
+
+    shortened_id = id
+    matches_for_id = match_substrings(patterns_dict.keys(), shortened_id)
+
+    for pattern in matches_for_id:
+        shortened_id = re.sub(
+            r"({})".format(re.escape(pattern)),
+            patterns_dict[pattern],
+            shortened_id,
+        )
+    return (
+        shortened_id
+        if shortened_id[len(shortened_id) - 1] != "_"
+        else shortened_id[0 : (len(shortened_id) - 1)]
+    )
+
+
+def match_substrings(substrings, target_string):
+    pattern = "|".join(map(re.escape, substrings))
+    matches = re.findall(pattern, target_string)
+    return matches
+
+
+def generate_hash(string):
+    import hashlib
+
+    hash_object = hashlib.sha1(string.encode())
+    full_hash = hash_object.hexdigest()
+    short_hash = full_hash[:10]
+    return short_hash
+
+
+def fail_if_new_ids_not_valid(ids):
+    if len(ids) != len(set(ids)):
+        raise ValueError("Th new IDs are not unique")
+
+
+if __name__ == "__main__":
+    input_ids_and_descriptions = extract_fasta_ids_and_descriptions(fasta_file_path)
+    input_ids = [x[0] for x in input_ids_and_descriptions]
+
+    # Write versions
+    with open(f"versions.yml", "w") as f_versions:
+        f_versions.write('"${task.process}":\\n')
+        f_versions.write(f"    python: {python_version()}\\n")
+        f_versions.write(f"    biopython: {version('biopython')}\\n")
+
+    if not do_ids_need_to_change(input_ids_and_descriptions):
+        print("IDs have acceptable length and character. No change required.")
+        exit(0)
+
+    new_ids = shorten_ids(
+        input_ids_and_descriptions, extract_common_patterns(input_ids)
+    )
+    fail_if_new_ids_not_valid(new_ids)
+
+    with open(f"{output_files_prefix}.short.ids.tsv", "w") as f:
+        for input_id, new_id in zip(input_ids, new_ids):
+            f.write(f"{input_id}\\t{new_id}\\n")
+
+    write_fasta_with_new_ids(
+        fasta_file_path, zip(input_ids, new_ids), output_files_prefix
+    )

--- a/modules/pfr/custom/shortenfastaids/tests/main.nf.test
+++ b/modules/pfr/custom/shortenfastaids/tests/main.nf.test
@@ -1,0 +1,131 @@
+nextflow_process {
+
+    name "Test Process CUSTOM_SHORTENFASTAIDS"
+    script "../main.nf"
+    process "CUSTOM_SHORTENFASTAIDS"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "custom"
+    tag "custom/shortenfastaids"
+
+    test("homo_sapiens-genome_fasta-no_change") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() },
+                { assert snapshot(process.out.versions).match("versions") },
+                { assert process.out.short_ids_fasta == [] },
+                { assert process.out.short_ids_tsv == [] }
+            )
+        }
+
+    }
+
+    test("sarscov2-genome_fasta-pattern_change") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() },
+                { assert snapshot(process.out.versions).match("versions") }
+            )
+        }
+
+    }
+
+    test("homo_sapiens-genome2_fasta-length_change") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.test_data['homo_sapiens']['genome']['genome2_fasta'], checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() },
+                { assert snapshot(process.out.versions).match("versions") }
+            )
+        }
+
+    }
+
+    test("custom_fasta-comment_change") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of('>Chr1 This is a test comment', 'AGCTAGCT')
+                | collectFile(name: 'sample.fasta', newLine: true)
+                | map { file -> [ [ id:'test' ], file ] }
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() },
+                { assert snapshot(process.out.versions).match("versions") }
+            )
+        }
+
+    }
+
+    test("stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out.versions).match("versions") },
+                { assert process.out.short_ids_fasta == [] },
+                { assert process.out.short_ids_tsv == [] }
+            )
+        }
+
+    }
+
+}

--- a/modules/pfr/custom/shortenfastaids/tests/main.nf.test.snap
+++ b/modules/pfr/custom/shortenfastaids/tests/main.nf.test.snap
@@ -1,0 +1,170 @@
+{
+    "custom_fasta-comment_change": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.short.ids.fasta:md5,c861b9d46a4d9bdba66953cff572fc5d"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.short.ids.tsv:md5,8762f2bffbdff75c2812bad72ba52bba"
+                    ]
+                ],
+                "2": [
+                    "versions.yml:md5,e5704a53ebea373dac3a93ae800d48ba"
+                ],
+                "short_ids_fasta": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.short.ids.fasta:md5,c861b9d46a4d9bdba66953cff572fc5d"
+                    ]
+                ],
+                "short_ids_tsv": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.short.ids.tsv:md5,8762f2bffbdff75c2812bad72ba52bba"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,e5704a53ebea373dac3a93ae800d48ba"
+                ]
+            }
+        ],
+        "timestamp": "2023-12-07T13:33:05.523745"
+    },
+    "versions": {
+        "content": [
+            [
+                "versions.yml:md5,e5704a53ebea373dac3a93ae800d48ba"
+            ]
+        ],
+        "timestamp": "2023-12-07T13:30:30.361527"
+    },
+    "homo_sapiens-genome_fasta-no_change": {
+        "content": [
+            {
+                "0": [
+                    
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    "versions.yml:md5,e5704a53ebea373dac3a93ae800d48ba"
+                ],
+                "short_ids_fasta": [
+                    
+                ],
+                "short_ids_tsv": [
+                    
+                ],
+                "versions": [
+                    "versions.yml:md5,e5704a53ebea373dac3a93ae800d48ba"
+                ]
+            }
+        ],
+        "timestamp": "2023-12-07T13:32:54.220188"
+    },
+    "homo_sapiens-genome2_fasta-length_change": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.short.ids.fasta:md5,1382acd98d4cd233a8062ef01b2aaa6d"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.short.ids.tsv:md5,99c0f2a529cb595b2d8530024ed2880e"
+                    ]
+                ],
+                "2": [
+                    "versions.yml:md5,e5704a53ebea373dac3a93ae800d48ba"
+                ],
+                "short_ids_fasta": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.short.ids.fasta:md5,1382acd98d4cd233a8062ef01b2aaa6d"
+                    ]
+                ],
+                "short_ids_tsv": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.short.ids.tsv:md5,99c0f2a529cb595b2d8530024ed2880e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,e5704a53ebea373dac3a93ae800d48ba"
+                ]
+            }
+        ],
+        "timestamp": "2023-12-07T13:33:01.924483"
+    },
+    "sarscov2-genome_fasta-pattern_change": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.short.ids.fasta:md5,14d6f587b6d28889c5c0f985e78d602f"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.short.ids.tsv:md5,d7a2af88e8549586e5616bff6a88bd71"
+                    ]
+                ],
+                "2": [
+                    "versions.yml:md5,e5704a53ebea373dac3a93ae800d48ba"
+                ],
+                "short_ids_fasta": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.short.ids.fasta:md5,14d6f587b6d28889c5c0f985e78d602f"
+                    ]
+                ],
+                "short_ids_tsv": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.short.ids.tsv:md5,d7a2af88e8549586e5616bff6a88bd71"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,e5704a53ebea373dac3a93ae800d48ba"
+                ]
+            }
+        ],
+        "timestamp": "2023-12-07T13:32:58.12885"
+    }
+}

--- a/modules/pfr/custom/shortenfastaids/tests/tags.yml
+++ b/modules/pfr/custom/shortenfastaids/tests/tags.yml
@@ -1,0 +1,2 @@
+custom/shortenfastaids:
+  - "modules/pfr/custom/shortenfastaids/**"

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,2 +1,12 @@
-conda.createTimeout = '1h'
-nextflow.enable.moduleBinaries = true
+includeConfig './conf/base.config'
+
+conda.createTimeout     = '1h' // base+
+
+params.outdir           = './results'
+params.publish_dir_mode = 'copy'
+params.max_cpus         = 8
+params.max_memory       = 16.GB
+params.max_time         = 4.h
+
+includeConfig './conf/modules.config'
+includeConfig './conf/reporting_defaults.config'


### PR DESCRIPTION
Hi @jguhlin 

I have added the ltrretriever workflow by using nf-core implementation style. There is lot going on in this PR and it might be easier to talk in person. Here, I'll summarise the key changes.

- We can switch back and forth between the original implementation (WORKFLOW_A) and the nf-core style implementation (WORKFLOW_B) by (un)commenting line 331 in `main.nf`
- Installed the modules from nf-core and PFR local repo with `nf-core -v modules install <tool/subtool>`
- Added execution profiles for local, PFR, docker, singularity and conda. To test with conda, please do:

```bash
./main.nf -profile local,conda -resume -c conf/test.config
```

- WORKFLOW_B also supports `-stub` and I have used to create a minimal continuous integration workflow.

Cheers